### PR TITLE
Fix error due to wp_get_attachment_image_url expecting int

### DIFF
--- a/includes/class-wp-term-images.php
+++ b/includes/class-wp-term-images.php
@@ -100,7 +100,7 @@ final class WP_Term_Images extends WP_Term_Meta_UI {
 	}
 
 	/**
-	 * Return the formatted output for the colomn row
+	 * Return the formatted output for the column row
 	 *
 	 * @since 0.1.2
 	 *

--- a/includes/class-wp-term-images.php
+++ b/includes/class-wp-term-images.php
@@ -17,17 +17,17 @@ if ( ! class_exists( 'WP_Term_Images' ) ) :
  *
  * @since 0.1.0
  */
-final class WP_Term_Images extends JJJ\WP\Term\Meta\UI {
+final class WP_Term_Images extends WP_Term_Meta_UI {
 
 	/**
 	 * @var string Plugin version
 	 */
-	public $version = '2.0.0';
+	public $version = '1.0.0';
 
 	/**
 	 * @var string Database version
 	 */
-	public $db_version = 201905300001;
+	public $db_version = 201701160001;
 
 	/**
 	 * @var string Metadata key
@@ -100,7 +100,7 @@ final class WP_Term_Images extends JJJ\WP\Term\Meta\UI {
 	}
 
 	/**
-	 * Return the formatted output for the column row
+	 * Return the formatted output for the colomn row
 	 *
 	 * @since 0.1.2
 	 *
@@ -154,9 +154,12 @@ final class WP_Term_Images extends JJJ\WP\Term\Meta\UI {
 
 		// Get the meta value
 		$value  = $this->get_meta( $term_id );
-		$hidden = empty( $value )
-			? ' style="display: none;"'
-			: ''; ?>
+		$hidden = '';
+
+		if ( empty( $value ) ) {
+			$hidden = ' style="display: none;"';
+			$value = 0;
+		} ?>
 
 		<div>
 			<img id="wp-term-images-photo" src="<?php echo esc_url( wp_get_attachment_image_url( $value, 'full' ) ); ?>"<?php echo $hidden; ?> />

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors:      johnjamesjacoby, stuttter
 Tags:              taxonomy, term, meta, metadata, image, images
 Requires PHP:      5.6.20
 Requires at least: 4.4
-Tested up to:      5.2
-Stable tag:        2.0.0
+Tested up to:      5.7
+Stable tag:        2.0.1
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 Donate link:       https://ko-fi.com/jjj
@@ -84,6 +84,9 @@ if ( ! empty( $image ) ) {
 http://github.com/stuttter/wp-term-images/
 
 == Changelog ==
+
+= [2.0.1] - 2022-03-09 =
+* Fix fatal error
 
 = [2.0.0] - 2019-05-30 =
 * Update base class

--- a/wp-term-images.php
+++ b/wp-term-images.php
@@ -8,7 +8,7 @@
  * License:     GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Description: Pretty images for categories, tags, and other taxonomy terms
- * Version:     2.0.0
+ * Version:     2.0.1
  * Text Domain: wp-term-images
  * Domain Path: /assets/lang/
  */


### PR DESCRIPTION
Fix fatal error that was being caused by a variable type mismatch since wp_get_attachment_image_url expected an int but was being passed a string in the variable $value.

![fata-error-screenshot](https://user-images.githubusercontent.com/14850570/157433851-eae3a379-846f-450a-8728-fda5911d8dc1.png)

